### PR TITLE
prepublish to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "prepublish": "npm run ngc",
+    "prepare": "npm run ngc",
     "ng": "ng",
     "start": "ng serve",
     "test": "ng test --single-run",


### PR DESCRIPTION
Fixing the following warning: 


```bash
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```
change 'prepublish' to 'prepare'