### PR TITLE
add hammerjs support

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -20,7 +20,9 @@
       "styles": [
         "styles.css"
       ],
-      "scripts": [],
+      "scripts": [
+          "../node_modules/hammerjs/hammer.min.js"
+      ],
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev": "environments/environment.ts",

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -2,6 +2,7 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
 import { environment } from './environments/environment';
 import { AppModule } from './app/app.module';
+import 'hammerjs';
 
 if (environment.production) {
   enableProdMode();

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "@angular/platform-browser": "^4.4.3",
     "@angular/platform-browser-dynamic": "^4.4.3",
     "@angular/router": "^4.4.3",
+    "@types/hammerjs": "^2.0.34",
+    "hammerjs": "^2.0.8",
     "@types/jasmine": "2.5.54",
     "@types/node": "6.0.88",
     "codelyzer": "3.1.2",


### PR DESCRIPTION
The browser console reports the following when we load the pages. 
```console
Could not find HammerJS. Certain Angular Material components may not work correctly.
```
Adding gesture support  using hammerjs as well. 

More details here:
https://material.angular.io/guide/getting-started#step-5-gesture-support.
