### PR TITLE
do not distribute ts in npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,3 +20,7 @@ dist
 config
 angular-cli.json
 LICENSE
+
+# Ignored files
+*.ts
+!*.d.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+### 1.5.0 (under development)
+
+Issue #75  - Fix npm distribution issue. See #69 and #72 for more details.
+
+#### 1.4.5
+
+Issue #71 - angular5 dependency
+
+### 1.4.0
+
+## 1.0.0


### PR DESCRIPTION
As per  https://github.com/angular/angular-cli/issues/8284#issuecomment-341417325 - distributing .ts seems to be a problem and not the recommended way of doing things (with version incompatibility between typescript versions)

```
"You have TS files in your node_modules. This really goes against how libraries should be packaged: libraries should never ship their source .ts files."
```

Ignore .ts but distribute .d.ts though. 

This seems to address the issue in #69 , (reported again in #72) as well 
